### PR TITLE
adding dimension Blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@
 * Faster world loading (*inspired* by VanillaFix, LOL)
 * Blacklist for block destruction on tower collapse
 * Difficulty persistent tower golems (no despawning in peaceful mode)
-* Dimension blacklist for Battle Towers world generation and position-file load/save handling
+* Dimension blacklist/whitelist for Battle Towers world generation and position-file load/save handling
 
 Requires [AtomicStryker's Battle Towers](https://www.curseforge.com/minecraft/mc-mods/atomicstrykers-battle-towers) and [MixinBooter](https://www.curseforge.com/minecraft/mc-mods/mixin-booter).

--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@
 * Faster world loading (*inspired* by VanillaFix, LOL)
 * Blacklist for block destruction on tower collapse
 * Difficulty persistent tower golems (no despawning in peaceful mode)
+* Dimension blacklist for Battle Towers world generation and position-file load/save handling
 
 Requires [AtomicStryker's Battle Towers](https://www.curseforge.com/minecraft/mc-mods/atomicstrykers-battle-towers) and [MixinBooter](https://www.curseforge.com/minecraft/mc-mods/mixin-booter).

--- a/src/main/java/mod/acgaming/btfixes/config/BTFixesConfig.java
+++ b/src/main/java/mod/acgaming/btfixes/config/BTFixesConfig.java
@@ -40,16 +40,26 @@ public class BTFixesConfig
     public static int bufferTime = 100;
 
     @Config.RequiresWorldRestart
+    @Config.Name("Treat Dimension Blacklist As Whitelist")
+    @Config.Comment
+            ({
+                    "If true, the dimension blacklist is treated as a whitelist instead",
+                    "Whitelist mode: only listed dimensions are allowed",
+                    "Warning: an empty list in whitelist mode blocks Battle Towers in all dimensions"
+            })
+    public static boolean dimensionListIsWhitelist = false;
+
+    @Config.RequiresWorldRestart
     @Config.Name("Dimension Blacklist")
     @Config.Comment
             ({
-                    "Dimension IDs where Battle Towers should not generate from worldgen",
-                    "Also prevents Battle Towers position-file load/save handling for those dimensions",
+                    "Dimension IDs used by the dimension blacklist/whitelist",
+                    "Also affects Battle Towers position-file load/save handling for those dimensions",
                     "Example:",
                     "143",
                     "32",
                     "14",
-                    "Leave empty to allow Battle Towers in all dimensions"
+                    "Leave empty to allow Battle Towers in all dimensions when whitelist mode is disabled"
             })
     public static int[] dimensionBlacklist = new int[0];
 

--- a/src/main/java/mod/acgaming/btfixes/config/BTFixesConfig.java
+++ b/src/main/java/mod/acgaming/btfixes/config/BTFixesConfig.java
@@ -40,6 +40,20 @@ public class BTFixesConfig
     public static int bufferTime = 100;
 
     @Config.RequiresWorldRestart
+    @Config.Name("Dimension Blacklist")
+    @Config.Comment
+            ({
+                    "Dimension IDs where Battle Towers should not generate from worldgen",
+                    "Also prevents Battle Towers position-file load/save handling for those dimensions",
+                    "Example:",
+                    "143",
+                    "32",
+                    "14",
+                    "Leave empty to allow Battle Towers in all dimensions"
+            })
+    public static int[] dimensionBlacklist = new int[0];
+
+    @Config.RequiresWorldRestart
     @Config.Name("Destruction Blacklist")
     @Config.Comment
         ({

--- a/src/main/java/mod/acgaming/btfixes/mixin/WorldGenHandlerMixin.java
+++ b/src/main/java/mod/acgaming/btfixes/mixin/WorldGenHandlerMixin.java
@@ -20,7 +20,7 @@ public class WorldGenHandlerMixin
     @Inject(method = "generate", at = @At("HEAD"), cancellable = true)
     private void btfixes$generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider, CallbackInfo ci)
     {
-        if (btfixes$isDimensionBlacklisted(world))
+        if (btfixes$shouldBlockDimension(world))
         {
             ci.cancel();
             return;
@@ -37,14 +37,14 @@ public class WorldGenHandlerMixin
         /*
          * Keep BattleTowers' original worldMap cleanup behavior.
          * Normally this happens inside eventWorldLoad(), but if we cancel at HEAD
-         * for a blacklisted dimension, preserve this part manually.
+         * for a blocked dimension, preserve this part manually.
          */
         if (WorldGenHandler.shouldClearWorldMap)
         {
             WorldGenHandler.wipeWorldHandles();
             WorldGenHandler.shouldClearWorldMap = false;
         }
-        if (btfixes$isDimensionBlacklisted(event.getWorld()))
+        if (btfixes$shouldBlockDimension(event.getWorld()))
         {
             ci.cancel();
         }
@@ -53,22 +53,36 @@ public class WorldGenHandlerMixin
     @Inject(method = "eventWorldSave", at = @At("HEAD"), cancellable = true)
     private void btfixes$eventWorldSave(WorldEvent.Save event, CallbackInfo ci)
     {
-        if (btfixes$isDimensionBlacklisted(event.getWorld()))
+        if (btfixes$shouldBlockDimension(event.getWorld()))
         {
             ci.cancel();
         }
     }
 
-    private static boolean btfixes$isDimensionBlacklisted(World world)
+    private static boolean btfixes$shouldBlockDimension(World world)
     {
-        if (world == null || world.provider == null || BTFixesConfig.dimensionBlacklist == null)
+        if (world == null || world.provider == null)
         {
             return false;
         }
-        int dimension = world.provider.getDimension();
-        for (int blacklistedDimension : BTFixesConfig.dimensionBlacklist)
+        boolean dimensionIsListed = btfixes$isDimensionListed(world.provider.getDimension());
+
+        if (BTFixesConfig.dimensionListIsWhitelist)
         {
-            if (dimension == blacklistedDimension)
+            return !dimensionIsListed;
+        }
+        return dimensionIsListed;
+    }
+
+    private static boolean btfixes$isDimensionListed(int dimension)
+    {
+        if (BTFixesConfig.dimensionBlacklist == null)
+        {
+            return false;
+        }
+        for (int listedDimension : BTFixesConfig.dimensionBlacklist)
+        {
+            if (dimension == listedDimension)
             {
                 return true;
             }

--- a/src/main/java/mod/acgaming/btfixes/mixin/WorldGenHandlerMixin.java
+++ b/src/main/java/mod/acgaming/btfixes/mixin/WorldGenHandlerMixin.java
@@ -5,7 +5,7 @@ import java.util.Random;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.IChunkGenerator;
-
+import net.minecraftforge.event.world.WorldEvent;
 import atomicstryker.battletowers.common.WorldGenHandler;
 import mod.acgaming.btfixes.config.BTFixesConfig;
 import mod.acgaming.btfixes.util.ServerTimeHelper;
@@ -17,9 +17,62 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(value = WorldGenHandler.class, remap = false)
 public class WorldGenHandlerMixin
 {
-    @Inject(method = "generate", at = @At(value = "HEAD"), cancellable = true)
-    public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider, CallbackInfo ci)
+    @Inject(method = "generate", at = @At("HEAD"), cancellable = true)
+    private void btfixes$generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider, CallbackInfo ci)
     {
-        if (world.getTotalWorldTime() < ServerTimeHelper.startingTime + BTFixesConfig.bufferTime) ci.cancel();
+        if (btfixes$isDimensionBlacklisted(world))
+        {
+            ci.cancel();
+            return;
+        }
+        if (world.getTotalWorldTime() < ServerTimeHelper.startingTime + BTFixesConfig.bufferTime)
+        {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "eventWorldLoad", at = @At("HEAD"), cancellable = true)
+    private void btfixes$eventWorldLoad(WorldEvent.Load event, CallbackInfo ci)
+    {
+        /*
+         * Keep BattleTowers' original worldMap cleanup behavior.
+         * Normally this happens inside eventWorldLoad(), but if we cancel at HEAD
+         * for a blacklisted dimension, preserve this part manually.
+         */
+        if (WorldGenHandler.shouldClearWorldMap)
+        {
+            WorldGenHandler.wipeWorldHandles();
+            WorldGenHandler.shouldClearWorldMap = false;
+        }
+        if (btfixes$isDimensionBlacklisted(event.getWorld()))
+        {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "eventWorldSave", at = @At("HEAD"), cancellable = true)
+    private void btfixes$eventWorldSave(WorldEvent.Save event, CallbackInfo ci)
+    {
+        if (btfixes$isDimensionBlacklisted(event.getWorld()))
+        {
+            ci.cancel();
+        }
+    }
+
+    private static boolean btfixes$isDimensionBlacklisted(World world)
+    {
+        if (world == null || world.provider == null || BTFixesConfig.dimensionBlacklist == null)
+        {
+            return false;
+        }
+        int dimension = world.provider.getDimension();
+        for (int blacklistedDimension : BTFixesConfig.dimensionBlacklist)
+        {
+            if (dimension == blacklistedDimension)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

Adds a config option to blacklist dimensions from Battle Towers worldgen.

Blacklisted dimensions also skip Battle Towers position-file load/save handling. The default list is empty, so existing behavior is unchanged.

## Changes

- Added `Dimension Blacklist` config option
- Cancels Battle Towers worldgen early in listed dimensions
- Skips Battle Towers position-file load/save handling in listed dimensions
- Keeps the existing buffer timer behavior for non-blacklisted dimensions

## Notes

Manual admin commands are not blocked. Operators can still use commands like `/spawnbattletower` in blacklisted dimensions.

Meant to fix BS like this in bigger modpacks. (battletower in voidworld spamming lag)
```
[18:11:34] [Server thread/WARN] [FML]: Battle Towers loaded a new chunk [9, 43] in dimension 43 (simplevoidworld) while populating chunk [10, 44], causing cascading worldgen lag.
```